### PR TITLE
Explicitly denote EULA acceptance in setup guide

### DIFF
--- a/content/en/docs/Anka Build Cloud/Virtualization CLI/partials/_install-guide.md
+++ b/content/en/docs/Anka Build Cloud/Virtualization CLI/partials/_install-guide.md
@@ -35,3 +35,8 @@ anka version
 ```shell
 sudo anka license activate <key>
 ```
+
+#### Accept the Anka EULA
+```shell
+sudo anka license accept-eula
+```


### PR DESCRIPTION
The current version of the "Getting Started" guide fails to mention that the user must accept the Anka EULA after activating their license key.

While it probably seems pretty obvious to most Anka users that they need to accept the EULA (given that the error output when they _haven't_ accepted the EULA is easy to comprehend), I think it would be nice to explicitly call this out in the documentation.