### PR TITLE
Use same temp name during push as during create

### DIFF
--- a/content/en/docs/Getting Started/partials/_push-vm-to-registry.md
+++ b/content/en/docs/Getting Started/partials/_push-vm-to-registry.md
@@ -1,5 +1,5 @@
 ```shell
-sudo anka registry push catalina -t base
+sudo anka registry push 10.15.4 -t base
 ```
 
 After the push completes, you should see your new Template in the "Templates" section of the controller UI.


### PR DESCRIPTION
Under the `Generate the Template` section, the docs use `10.15.4` as the template name when running `anka create`. 

Then in this section of the docs (`Push the VM to the Registry `) the VM is referenced as `catalina`

If this guide is followed verbatim (i.e. someone blindly copypasta's the commands) it will throw this error:
```
my-anka-node:~ ankatest$ sudo anka registry push catalina -t base
-anka: catalina: not found
```

I am proposing this partial be changed to use `10.15.4` so the referenced commands remain consistent and follow the template naming best practice [1] which is outlined in this doc.

[1] See below:
```
We recommend adding a version to the Template name so it's clear what version of OSX it is.
```